### PR TITLE
Add parent slug to add_submenu_page function

### DIFF
--- a/acf-image-aspect-ratio-crop.php
+++ b/acf-image-aspect-ratio-crop.php
@@ -279,7 +279,7 @@ class npx_acf_plugin_image_aspect_ratio_crop
         // Add plugin to WordPress admin menu
         add_action('admin_menu', function () {
             add_submenu_page(
-                null,
+                'options-general.php',
                 __(
                     'ACF Image Aspect Ratio Crop',
                     'acf-image-aspect-ratio-crop'


### PR DESCRIPTION
This commit fixes an issue where the 'add_submenu_page' function was missing the required '$parent_slug' parameter. Previously, the function was called with 'null' for the '$parent_slug', which was causing issues in WordPress 6.2 and PHP 8.2.

The solution implemented is to use 'options-general.php' as the parent slug. This places the "ACF Image Aspect Ratio