### PR TITLE
Load plugin text domain on 'init' action for WP 6.7 compatibility

### DIFF
--- a/acf-image-aspect-ratio-crop.php
+++ b/acf-image-aspect-ratio-crop.php
@@ -60,7 +60,11 @@ class npx_acf_plugin_image_aspect_ratio_crop
 
         // set text domain
         // https://codex.wordpress.org/Function_Reference/load_plugin_textdomain
-        load_plugin_textdomain('acf-image-aspect-ratio-crop');
+        add_action('init',
+            function () {
+                load_plugin_textdomain('acf-image-aspect-ratio-crop');
+            }
+        );
 
         add_action('plugins_loaded', [$this, 'initialize_settings']);
 


### PR DESCRIPTION
This pull request updates the loading of the plugin's text domain to occur on the 'init' action hook, ensuring compatibility with WordPress 6.7 and adherence to proper plugin initialization standards.
Source: [https://make.wordpress.org/core/2024/10/21/i18n-improvements-6-7/](https://make.wordpress.org/core/2024/10/21/i18n-improvements-6-7/)

Previously, the text domain was being loaded too early in the WordPress lifecycle, triggering a warning.

Changes made:
- Moved the call to load_plugin_textdomain() to run on the 'init' action hook.