### PR TITLE
Fix: Adjust text domain loading for WordPress 6.7.0+ compatibility

### DIFF
--- a/acf-image-aspect-ratio-crop.php
+++ b/acf-image-aspect-ratio-crop.php
@@ -60,7 +60,9 @@ class npx_acf_plugin_image_aspect_ratio_crop
 
         // set text domain
         // https://codex.wordpress.org/Function_Reference/load_plugin_textdomain
-        load_plugin_textdomain('acf-image-aspect-ratio-crop');
+        add_action('init', function () {
+            load_plugin_textdomain('acf-image-aspect-ratio-crop');
+        });
 
         add_action('plugins_loaded', [$this, 'initialize_settings']);
 


### PR DESCRIPTION
- Moved `load_plugin_textdomain` call to the 'init' action in the constructor.
- Resolves deprecation notice for early translation loading in WordPress 6.7.0+.
- Ensures compatibility with updated WordPress translation loading requirements.

Tested and verified to remove the notice in a local environment.